### PR TITLE
Remove scheduled tests

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -6,8 +6,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: '0 0 * * *'  # every day at midnight
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
Tests run on PR and push to main; we don't need them to run nightly as well, especially as GitHub Actions disables any scheduled job that has no activity for 60 days.