### PR TITLE
fix curl_close() for PHP 8.5

### DIFF
--- a/lib/WebDriver/Service/CurlService.php
+++ b/lib/WebDriver/Service/CurlService.php
@@ -132,7 +132,7 @@ class CurlService implements CurlServiceInterface
             throw $e;
         }
 
-        curl_close($curl);
+        $curl = null;
 
         return array($rawResult, $info);
     }


### PR DESCRIPTION
The `curl_close()` is deprecated in PHP 8.5

-   https://wiki.php.net/rfc/deprecations_php_8_5#introduction
-   https://github.com/php/php-src/commit/9b13bb1ae45f2e8abf6a702b64fd2333a23fc341